### PR TITLE
feat(infra): implement internal SSL between gateway and frontend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,3 +58,12 @@ DB_PASSWORD=sql_pass
 
 DB_CONTAINER_NAME=database
 SERVICE_CONTAINER_NAME=data-service
+
+# ===============================================================================================
+# SSL CERTIFICATES CONFIGURATION
+# ===============================================================================================
+
+CA_CRT_NAME=ca.crt
+CA_KEY_NAME=ca.key
+INT_CRT_NAME=internal.crt
+INT_KEY_NAME=internal.key

--- a/srcs/docker-compose.yaml
+++ b/srcs/docker-compose.yaml
@@ -5,3 +5,7 @@ include:
   - ./database/docker-compose.yaml
   - ./backend/docker-compose.yaml
   - ./frontend/docker-compose${FRONTEND_MODE:+-${FRONTEND_MODE}}.yaml
+  - ./pki/docker-compose.yaml
+
+volumes:
+  certs_data:

--- a/srcs/frontend/Dockerfile
+++ b/srcs/frontend/Dockerfile
@@ -24,8 +24,5 @@ FROM nginx:alpine
 # Copy the compiled static files from the 'builder' stage
 COPY --from=builder /app/dist /usr/share/nginx/html
 
-# Expose port 80 internally
-EXPOSE 80
-
 # Start Nginx
 CMD ["nginx", "-g", "daemon off;"]

--- a/srcs/frontend/default.conf
+++ b/srcs/frontend/default.conf
@@ -1,0 +1,26 @@
+server {
+    root /usr/share/nginx/html;
+    index index.html;
+
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    server_name frontend;
+
+    ssl_certificate /certs/${INT_CRT_NAME};
+    ssl_certificate_key /certs/${INT_KEY_NAME};
+
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers HIGH:!aNULL:!MD5;
+    ssl_prefer_server_ciphers on;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}
+
+server {
+    listen 80;
+    listen [::]:80;
+    server_name frontend;
+    return 301 https://$host$request_uri;
+}

--- a/srcs/frontend/docker-compose.yaml
+++ b/srcs/frontend/docker-compose.yaml
@@ -4,5 +4,14 @@ services:
       context: .
       dockerfile: Dockerfile
     container_name: frontend
+    environment:
+      - INT_CRT_NAME=${INT_CRT_NAME:-internal.crt}
+      - INT_KEY_NAME=${INT_KEY_NAME:-internal.key}
+      - ENVSUBST_VARS=INT_CRT_NAME,INT_KEY_NAME
+    volumes:
+      - ./default.conf:/etc/nginx/templates/default.conf.template:ro
+      - certs_data:/certs:ro
     restart: always
-
+    depends_on:
+      pki-init:
+        condition: service_completed_successfully

--- a/srcs/gateway/default.conf
+++ b/srcs/gateway/default.conf
@@ -38,8 +38,12 @@ server {
     location / {
         limit_req zone=global_zone burst=50 nodelay;
 
-        set $frontend_service "http://frontend:80";
+        set $frontend_service "https://frontend:443";
         proxy_pass $frontend_service;
+
+        # Internal SSL Trust Verification
+        proxy_ssl_verify on;
+        proxy_ssl_trusted_certificate /certs/${CA_CRT_NAME};
     }
 
     # Security Zone (Logins)

--- a/srcs/gateway/docker-compose.ssl.yaml
+++ b/srcs/gateway/docker-compose.ssl.yaml
@@ -6,12 +6,19 @@ services:
     ports:
       - "80:80"
       - "443:443"
+    environment:
+      - CA_CRT_NAME=${CA_CRT_NAME:-ca.crt}
+      - ENVSUBST_VARS=CA_CRT_NAME
     volumes:
       - ./default.conf:/etc/nginx/conf.d/default.conf:ro
+      - certs_data:/certs:ro
     secrets:
       - ssl_cert
       - ssl_key
     restart: always
+    depends_on:
+      pki-init:
+        condition: service_completed_successfully
 
 secrets:
   ssl_cert:

--- a/srcs/gateway/docker-compose.yaml
+++ b/srcs/gateway/docker-compose.yaml
@@ -6,6 +6,13 @@ services:
     ports:
       - "80:80"
       - "443:443"
+    environment:
+      - CA_CRT_NAME=${CA_CRT_NAME:-ca.crt}
+      - ENVSUBST_VARS=CA_CRT_NAME
     volumes:
-      - ./default.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./default.conf:/etc/nginx/templates/default.conf.template:ro
+      - certs_data:/certs:ro
     restart: always
+    depends_on:
+      pki-init:
+        condition: service_completed_successfully

--- a/srcs/pki/docker-compose.yaml
+++ b/srcs/pki/docker-compose.yaml
@@ -1,0 +1,13 @@
+services:
+  pki-init:
+    image: alpine:latest
+    container_name: pki-init
+    environment:
+      - CA_CRT_NAME=${CA_CRT_NAME:-ca.crt}
+      - CA_KEY_NAME=${CA_KEY_NAME:-ca.key}
+      - INT_CRT_NAME=${INT_CRT_NAME:-internal.crt}
+      - INT_KEY_NAME=${INT_KEY_NAME:-internal.key}
+    volumes:
+      - certs_data:/certs
+      - ./scripts/gen-certs.sh:/scripts/gen-certs.sh:ro
+    command: /bin/sh -c "apk add --no-cache openssl && sh /scripts/gen-certs.sh"

--- a/srcs/pki/scripts/gen-certs.sh
+++ b/srcs/pki/scripts/gen-certs.sh
@@ -1,0 +1,69 @@
+#!/bin/sh
+set -e
+
+CERTS_DIR="/certs"
+# Use environment variables passed from docker-compose
+CA_KEY="$CERTS_DIR/${CA_KEY_NAME}"
+CA_CRT="$CERTS_DIR/${CA_CRT_NAME}"
+INT_KEY="$CERTS_DIR/${INT_KEY_NAME}"
+INT_CSR="$CERTS_DIR/internal.csr"
+INT_CRT="$CERTS_DIR/${INT_CRT_NAME}"
+SAN_CONF="$CERTS_DIR/san.cnf"
+
+# 1. Skip if already generated to maintain trust across restarts
+if [ -f "$CA_CRT" ]; then
+    echo "Certificates already exist in volume. Skipping generation."
+    exit 0
+fi
+
+echo "Generating Root CA..."
+openssl genrsa -out "$CA_KEY" 4096
+openssl req -x509 -new -nodes -key "$CA_KEY" -sha256 -days 3650 -out "$CA_CRT" -subj "/CN=Transcendence Internal CA/O=Transcendence/C=BR"
+
+echo "Generating Internal Server Key..."
+openssl genrsa -out "$INT_KEY" 2048
+
+echo "Creating SAN configuration..."
+cat > "$SAN_CONF" <<EOF
+[req]
+default_bits = 2048
+prompt = no
+default_md = sha256
+req_extensions = req_ext
+distinguished_name = dn
+
+[dn]
+C = BR
+O = Transcendence
+CN = internal-services
+
+[req_ext]
+subjectAltName = @alt_names
+
+[alt_names]
+# Bare service names used by Docker Compose internal DNS
+DNS.1 = loki
+DNS.2 = promtail
+DNS.3 = backend
+DNS.4 = database
+DNS.5 = prometheus
+DNS.6 = gateway
+DNS.7 = grafana
+DNS.8 = data-service
+DNS.9 = frontend
+EOF
+
+echo "Generating Certificate Signing Request (CSR)..."
+openssl req -new -key "$INT_KEY" -out "$INT_CSR" -config "$SAN_CONF"
+
+echo "Generating Internal Certificate signed by Root CA..."
+openssl x509 -req -in "$INT_CSR" -CA "$CA_CRT" -CAkey "$CA_KEY" -CAcreateserial -out "$INT_CRT" -days 3650 -sha256 -extfile "$SAN_CONF" -extensions req_ext
+
+# Clean up temporary files
+rm -f "$INT_CSR" "$SAN_CONF" "$CERTS_DIR"/*.srl
+
+echo "Setting standard file permissions..."
+chmod 644 "$CERTS_DIR"/*.crt
+chmod 600 "$CERTS_DIR"/*.key
+
+echo "PKI Initialization Complete."


### PR DESCRIPTION
## Objective
Secures internal traffic between the Gateway and the Frontend service by enforcing end-to-end encryption (TLS) using our internal PKI setup. The Gateway now actively verifies the Frontend's identity before proxying traffic.

## Key Changes
* **Shared PKI Integration:** Mounted the `certs_data` volume to both the gateway and frontend containers as read-only.
* **Frontend TLS Termination:** Updated the frontend Nginx configuration to listen on port `443 ssl` and serve the dynamic internal certificates.
* **Strict Gateway Verification:** Updated the gateway `proxy_pass` to route to `https://frontend:443` and added `proxy_ssl_verify on;` to validate the frontend's certificate against the internal Root CA.
* **Dynamic Configuration:** Migrated `default.conf` to `default.conf.template` in both services to allow Docker's built-in `envsubst` to dynamically inject certificate filenames from the `.env` file.

## Testing
* Verified the gateway successfully establishes a TLS 1.2/1.3 connection to the frontend.
