### PR TITLE
Implemented the backend for the online feature using redis TTL

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -21,6 +21,9 @@ Here is a complete list of APIs used in this project, separated by cateories in 
       - [/api/follow/followers/{user_id}/](#/api/follow/followers/{user_id}/)
       - [/api/follow/counts/{user_id}/](#/api/follow/counts/{user_id}/)
       - [/api/follow/feed/{user_id}/](#/api/follow/feed/{user_id}/)
+    - [Presence](#presence)
+      - [/api/presence/ping/](#/api/presence/ping/)
+      - [/api/presence/](#/api/presence/)
   - [Database APIs](#database-apis)
 - [Public APIs](#public-apis)
 
@@ -195,6 +198,23 @@ Auth required: No
 Feed of active product listings posted by every user that `user_id` follows, newest first. Each item carries both the listing and the seller info so the frontend can render a card without extra requests. Optional pagination: `?limit=N` (1–100) or `?limit=N&offset=M`.
 Body: (none)
 Returns: [ { listing: { id, name, slug, price, created_at, image_hash }, user: { user_id, name, avatar_url, following_since } } ]
+Auth required: No
+
+### Presence / Online Status
+
+This power the online/offline indicator on user profiles, seller cards and chat lists. State lives in Redis with a 60s TTL: while a user has the tab open, the frontend POST a request every 30s; if no answer arrives within 60s the key expires and the user is reported offline. There is no database table — restarts of the backend simply clear all presence and users repopulate it on the next ping.
+
+#### POST /api/presence/ping/
+Refreshes the caller online status (resets the 60s TTL in Redis). The user id is taken from the JWT.
+Body: (none)
+Returns: 204 No Content
+Auth required: Yes (Bearer header)
+
+#### GET /api/presence/
+Bulk online-status lookup for a list of users. Public. Pass the ids as a comma-separated query string. Maximum 200 ids per request.
+Query: `?ids=1,2,3`
+Body: (none)
+Returns: { "1": true, "2": false, "3": true }
 Auth required: No
 
 ## Database APIs

--- a/srcs/backend/app/api/presence.py
+++ b/srcs/backend/app/api/presence.py
@@ -1,0 +1,45 @@
+"""
+Online Status/presence is backed only by Redis TTL (Time to Live) withoud websockets yet.
+
+The frontend will ping POST /api/presence/ping/ every 30s while a tab is open.
+Each ping refreshes a short-lived key in Redis (TTL = 60s). If the key exists,
+the user is "online"; if it expired (no ping in 60s), the user is "offline".
+Redis will manage and delete the keys on its own.
+"""
+
+import os
+import redis
+
+_redis_client = None
+PRESENCE_TTL_SECONDS = 60          # it allows one missed 30s ping to avoid wrong offline status caused by setwork problems
+PRESENCE_KEY_PREFIX = "presence:"
+
+def _client():
+    """ create the Redis connection on first use """
+    global _redis_client
+    if _redis_client is None:
+        _redis_client = redis.Redis(
+            host=os.environ.get("REDIS_HOST", "redis"),
+            port=int(os.environ.get("REDIS_PORT", 6379)),
+            decode_responses=True,
+        )
+    return _redis_client
+
+def _key(user_id):
+    return f"{PRESENCE_KEY_PREFIX}{int(user_id)}"
+
+def mark_online(user_id):
+    """ refresh the user presence key with a fresh TTL """
+    _client().set(_key(user_id), "1", ex=PRESENCE_TTL_SECONDS)
+
+def mark_offline(user_id):
+    """ explicit offline (on logout) or otherwise the key just expires """
+    _client().delete(_key(user_id))
+
+def are_online(user_ids):
+    """ batch check: returns for every id given (one round-trip) """
+    if not user_ids:
+        return {}
+    keys = [_key(uid) for uid in user_ids]
+    values = _client().mget(keys)
+    return {uid: (val is not None) for uid, val in zip(user_ids, values)}

--- a/srcs/backend/app/api/urls.py
+++ b/srcs/backend/app/api/urls.py
@@ -42,6 +42,8 @@ from .views import (
     auth_42_callback,
     chat_conversations,
     chat_messages,
+    presence_ping,
+    presence_query,
     admin_bans,
     manage_admins,
     manage_bans,
@@ -77,6 +79,10 @@ urlpatterns = [
         # chat paths
         path("chat/conversations/", chat_conversations.as_view()),
         path("chat/conversations/<int:conversation_id>/messages/", chat_messages.as_view()),
+
+        # presence paths
+        path("presence/ping/", presence_ping.as_view()),
+        path("presence/",      presence_query.as_view()),
 
         # follow paths
         path("follow/",                              follow_action.as_view()),

--- a/srcs/backend/app/api/views.py
+++ b/srcs/backend/app/api/views.py
@@ -12,6 +12,7 @@ from urllib.parse import urlencode
 from .permissions import IsAdminRole
 
 from . import serializers
+from . import presence as presence_store
 import requests
 import secrets
 import json
@@ -492,6 +493,39 @@ class chat_messages(APIView):
             "GET",
             f"/chat/conversations/{conversation_id}/messages/"
         )
+
+# --- PRESENCE API interfaces ---
+class presence_ping(APIView):
+    """ POST: refresh the caller online TTL key in Redis """
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request):
+        presence_store.mark_online(request.user.id)
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+class presence_query(APIView):
+    """ GET: return {user_id: bool} for a comma-separated ?ids= list. Public. """
+    permission_classes = [AllowAny]
+
+    MAX_IDS = 200
+
+    def get(self, request):
+        raw = request.query_params.get("ids", "")
+        if not raw:
+            return Response({})
+        try:
+            user_ids = [int(x) for x in raw.split(",") if x.strip()]
+        except ValueError:
+            return Response(
+                {"detail": "ids must be comma-separated integers"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        if len(user_ids) > self.MAX_IDS:
+            return Response(
+                {"detail": f"too many ids (max {self.MAX_IDS})"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        return Response(presence_store.are_online(user_ids))
 
 # --- FOLLOW API interfaces ---
 class follow_action(APIView):


### PR DESCRIPTION
Implemented the backend for the online feature using redis TTL (not websockets for now); there are now two api available, one for pinging the presence of the user and the other to check the status of a group of users (limited to 200 users to allow redis to manage it). The API are listed and explained in the API.md file. The idea is to make the online status public. My idea is to have one online status indicator near the username(online / offline color dot), for example in a product page. The TTL is not so robust/scalable as websockets, but it's easier to implement. It can take up 30 seconds to the indicator to be update after the user leaves, but this is reasonable for a marketplace. Ideally some more tests are needed but i sugest the merge to allow frontend to quickly start working and implement this feature. 